### PR TITLE
Fix missing meetings page

### DIFF
--- a/drfeinote/app/meetings/page.tsx
+++ b/drfeinote/app/meetings/page.tsx
@@ -1,0 +1,20 @@
+import { getMeetings } from "../actions"
+import { MeetingList } from "@/components/meeting-list"
+
+export default async function MeetingsPage() {
+  const upcomingMeetings = await getMeetings("upcoming")
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold tracking-tight">Upcoming Meetings</h1>
+        <p className="text-muted-foreground">Manage your scheduled meetings</p>
+      </div>
+
+      <MeetingList
+        meetings={upcomingMeetings}
+        emptyMessage="No upcoming meetings found"
+      />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add an Upcoming Meetings page so the `/meetings` link works

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_683b35bf0ae48326adcf5d73e7ac4cac