### PR TITLE
Add Supabase auth

### DIFF
--- a/drfeinote/README.md
+++ b/drfeinote/README.md
@@ -22,6 +22,15 @@ Continue building your app on:
 
 **[https://v0.dev/chat/projects/6gUaOTCbHon](https://v0.dev/chat/projects/6gUaOTCbHon)**
 
+## Environment Variables
+
+Create a `.env` file based on `.env.example` and provide your Supabase project credentials:
+
+```
+NEXT_PUBLIC_SUPABASE_URL=<your-supabase-url>
+NEXT_PUBLIC_SUPABASE_ANON_KEY=<your-anon-key>
+```
+
 ## How It Works
 
 1. Create and modify your project using [v0.dev](https://v0.dev)

--- a/drfeinote/app/login/page.tsx
+++ b/drfeinote/app/login/page.tsx
@@ -1,0 +1,60 @@
+"use client"
+
+import { useState } from 'react'
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { supabase } from '@/lib/supabase'
+import { signIn } from '@/lib/auth'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import { useToast } from '@/hooks/use-toast'
+
+export default function LoginPage() {
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [loading, setLoading] = useState(false)
+  const router = useRouter()
+  const { toast } = useToast()
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setLoading(true)
+    const { error } = await signIn(supabase, email, password)
+    setLoading(false)
+    if (error) {
+      toast({ title: 'Sign in failed', description: error.message, variant: 'destructive' })
+    } else {
+      router.push('/')
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center">
+      <form onSubmit={handleSubmit} className="space-y-4 w-80">
+        <Input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+        />
+        <Input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+        />
+        <Button type="submit" className="w-full" disabled={loading}>
+          {loading ? 'Signing in...' : 'Sign In'}
+        </Button>
+        <p className="text-center text-sm">
+          Don&apos;t have an account?{' '}
+          <Link href="/signup" className="underline">
+            Sign up
+          </Link>
+        </p>
+      </form>
+    </div>
+  )
+}

--- a/drfeinote/app/signup/page.tsx
+++ b/drfeinote/app/signup/page.tsx
@@ -1,0 +1,61 @@
+"use client"
+
+import { useState } from 'react'
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { supabase } from '@/lib/supabase'
+import { signUp } from '@/lib/auth'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import { useToast } from '@/hooks/use-toast'
+
+export default function SignUpPage() {
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [loading, setLoading] = useState(false)
+  const router = useRouter()
+  const { toast } = useToast()
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setLoading(true)
+    const { error } = await signUp(supabase, email, password)
+    setLoading(false)
+    if (error) {
+      toast({ title: 'Sign up failed', description: error.message, variant: 'destructive' })
+    } else {
+      toast({ title: 'Check your email to confirm your account.' })
+      router.push('/')
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center">
+      <form onSubmit={handleSubmit} className="space-y-4 w-80">
+        <Input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+        />
+        <Input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+        />
+        <Button type="submit" className="w-full" disabled={loading}>
+          {loading ? 'Signing up...' : 'Sign Up'}
+        </Button>
+        <p className="text-center text-sm">
+          Already have an account?{' '}
+          <Link href="/login" className="underline">
+            Sign in
+          </Link>
+        </p>
+      </form>
+    </div>
+  )
+}

--- a/drfeinote/components/main-nav.tsx
+++ b/drfeinote/components/main-nav.tsx
@@ -1,12 +1,34 @@
 "use client"
 
 import Link from "next/link"
-import { usePathname } from "next/navigation"
+import { usePathname, useRouter } from "next/navigation"
+import { useEffect, useState } from "react"
 import { cn } from "@/lib/utils"
 import { CalendarIcon, ArchiveIcon, BookOpenIcon } from "lucide-react"
+import { supabase } from "@/lib/supabase"
+import { Button } from "@/components/ui/button"
 
 export function MainNav() {
   const pathname = usePathname()
+  const router = useRouter()
+  const [session, setSession] = useState<any>(null)
+
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data }) => setSession(data.session))
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      setSession(session)
+    })
+    return () => {
+      subscription.unsubscribe()
+    }
+  }, [])
+
+  const handleSignOut = async () => {
+    await supabase.auth.signOut()
+    router.push("/login")
+  }
 
   const navItems = [
     {
@@ -46,6 +68,17 @@ export function MainNav() {
             <span>{item.name}</span>
           </Link>
         ))}
+      </div>
+      <div className="ml-auto">
+        {session ? (
+          <Button variant="ghost" size="sm" onClick={handleSignOut}>
+            Sign Out
+          </Button>
+        ) : (
+          <Link href="/login" className="text-sm hover:underline">
+            Sign In
+          </Link>
+        )}
       </div>
     </nav>
   )

--- a/drfeinote/lib/__tests__/auth.test.ts
+++ b/drfeinote/lib/__tests__/auth.test.ts
@@ -1,0 +1,31 @@
+import { signIn, signUp } from '../auth'
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+test('signIn calls supabase.auth.signInWithPassword', async () => {
+  const calls: any[] = []
+  const supabase = {
+    auth: {
+      signInWithPassword: async (opts: any) => {
+        calls.push(opts)
+        return { data: {}, error: null }
+      }
+    }
+  }
+  await signIn(supabase as any, 'a@b.com', 'pass')
+  assert.deepEqual(calls[0], { email: 'a@b.com', password: 'pass' })
+})
+
+test('signUp calls supabase.auth.signUp', async () => {
+  const calls: any[] = []
+  const supabase = {
+    auth: {
+      signUp: async (opts: any) => {
+        calls.push(opts)
+        return { data: {}, error: null }
+      }
+    }
+  }
+  await signUp(supabase as any, 'a@b.com', 'pass')
+  assert.deepEqual(calls[0], { email: 'a@b.com', password: 'pass' })
+})

--- a/drfeinote/lib/auth.ts
+++ b/drfeinote/lib/auth.ts
@@ -1,0 +1,15 @@
+export async function signIn(
+  supabase: { auth: { signInWithPassword: (opts: { email: string; password: string }) => Promise<any> } },
+  email: string,
+  password: string
+) {
+  return supabase.auth.signInWithPassword({ email, password })
+}
+
+export async function signUp(
+  supabase: { auth: { signUp: (opts: { email: string; password: string }) => Promise<any> } },
+  email: string,
+  password: string
+) {
+  return supabase.auth.signUp({ email, password })
+}

--- a/drfeinote/lib/supabase.ts
+++ b/drfeinote/lib/supabase.ts
@@ -1,0 +1,6 @@
+import { createBrowserClient } from '@supabase/ssr'
+
+export const supabase = createBrowserClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+)

--- a/drfeinote/package-lock.json
+++ b/drfeinote/package-lock.json
@@ -16,7 +16,8 @@
         "next": "15.2.4",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "tailwind-merge": "^3.3.0"
+        "tailwind-merge": "^3.3.0",
+        "@supabase/supabase-js": "^2.43.3"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -6419,6 +6420,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.43.3",
+      "resolved": "",
+      "integrity": "",
+      "license": "MIT"
     }
   }
 }

--- a/drfeinote/package.json
+++ b/drfeinote/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "node --test"
   },
   "dependencies": {
     "@radix-ui/react-accordion": "^1.2.11",
@@ -17,7 +18,8 @@
     "next": "15.2.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "tailwind-merge": "^3.3.0"
+    "tailwind-merge": "^3.3.0",
+    "@supabase/supabase-js": "^2.43.3"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",


### PR DESCRIPTION
## Summary
- add Supabase client
- create sign up and sign in pages
- expose sign in/out in navigation
- add Supabase dependency and env example
- add auth helpers and unit tests

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `npm run build` *(fails: `next: not found`)*
- `npm test` *(runs no tests)*
- `node --test lib/__tests__/auth.test.ts` *(fails: `ERR_UNKNOWN_FILE_EXTENSION`)*

------
https://chatgpt.com/codex/tasks/task_b_683b39f3f2648326a84bd3e694a8f38b