### PR TITLE
Add Supabase Meeting Notes service

### DIFF
--- a/drfeinote/lib/__tests__/meeting-notes.test.ts
+++ b/drfeinote/lib/__tests__/meeting-notes.test.ts
@@ -1,0 +1,83 @@
+import { MeetingNotesService } from '../meeting-notes'
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+test('create inserts a meeting note', async () => {
+  const calls: any[] = []
+  const supabase = {
+    from: (table: string) => ({
+      insert: (vals: any) => {
+        calls.push({ table, vals })
+        return {
+          select: () => ({
+            single: async () => ({ data: { note_id: 1, ...vals }, error: null })
+          })
+        }
+      }
+    })
+  }
+
+  const svc = new MeetingNotesService(supabase as any)
+  const note = await svc.create(1, 'text')
+  assert.deepEqual(calls[0], { table: 'meeting_notes', vals: { meeting_id: 1, note_content: 'text' } })
+  assert.equal(note.note_content, 'text')
+})
+
+test('getById selects a note by id', async () => {
+  const calls: any[] = []
+  const supabase = {
+    from: (table: string) => ({
+      select: () => ({
+        eq: (field: string, value: any) => {
+          calls.push({ table, field, value })
+          return { maybeSingle: async () => ({ data: null, error: null }) }
+        }
+      })
+    })
+  }
+
+  const svc = new MeetingNotesService(supabase as any)
+  await svc.getById(5)
+  assert.deepEqual(calls[0], { table: 'meeting_notes', field: 'note_id', value: 5 })
+})
+
+test('update changes note content', async () => {
+  const calls: any[] = []
+  const supabase = {
+    from: (table: string) => ({
+      update: (vals: any) => ({
+        eq: (field: string, value: any) => {
+          calls.push({ table, field, value, vals })
+          return {
+            select: () => ({
+              single: async () => ({ data: { note_id: value, ...vals }, error: null })
+            })
+          }
+        }
+      })
+    })
+  }
+
+  const svc = new MeetingNotesService(supabase as any)
+  const note = await svc.update(3, 'updated')
+  assert.deepEqual(calls[0], { table: 'meeting_notes', field: 'note_id', value: 3, vals: { note_content: 'updated' } })
+  assert.equal(note.note_content, 'updated')
+})
+
+test('delete removes a note', async () => {
+  const calls: any[] = []
+  const supabase = {
+    from: (table: string) => ({
+      delete: () => ({
+        eq: (field: string, value: any) => {
+          calls.push({ table, field, value })
+          return { error: null }
+        }
+      })
+    })
+  }
+
+  const svc = new MeetingNotesService(supabase as any)
+  await svc.delete(2)
+  assert.deepEqual(calls[0], { table: 'meeting_notes', field: 'note_id', value: 2 })
+})

--- a/drfeinote/lib/meeting-notes.ts
+++ b/drfeinote/lib/meeting-notes.ts
@@ -1,0 +1,70 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import type { MeetingNote } from './types'
+
+/**
+ * Service class for CRUD operations on meeting notes using Supabase.
+ */
+export class MeetingNotesService {
+  constructor(private supabase: SupabaseClient) {}
+
+  /**
+   * Create a meeting note for a meeting.
+   */
+  async create(meetingId: number, content: string): Promise<MeetingNote> {
+    const { data, error } = await this.supabase
+      .from('meeting_notes')
+      .insert({ meeting_id: meetingId, note_content: content })
+      .select()
+      .single()
+
+    if (error) throw error
+    return data as MeetingNote
+  }
+
+  /** Get a meeting note by its id. */
+  async getById(noteId: number): Promise<MeetingNote | null> {
+    const { data, error } = await this.supabase
+      .from('meeting_notes')
+      .select('*')
+      .eq('note_id', noteId)
+      .maybeSingle()
+
+    if (error) throw error
+    return data as MeetingNote | null
+  }
+
+  /** Get the meeting note for a specific meeting. */
+  async getByMeetingId(meetingId: number): Promise<MeetingNote | null> {
+    const { data, error } = await this.supabase
+      .from('meeting_notes')
+      .select('*')
+      .eq('meeting_id', meetingId)
+      .maybeSingle()
+
+    if (error) throw error
+    return data as MeetingNote | null
+  }
+
+  /** Update the content of a meeting note. */
+  async update(noteId: number, content: string): Promise<MeetingNote> {
+    const { data, error } = await this.supabase
+      .from('meeting_notes')
+      .update({ note_content: content })
+      .eq('note_id', noteId)
+      .select()
+      .single()
+
+    if (error) throw error
+    return data as MeetingNote
+  }
+
+  /** Delete a meeting note. */
+  async delete(noteId: number): Promise<void> {
+    const { error } = await this.supabase
+      .from('meeting_notes')
+      .delete()
+      .eq('note_id', noteId)
+
+    if (error) throw error
+  }
+}


### PR DESCRIPTION
## Summary
- implement `MeetingNotesService` class to manage CRUD operations with Supabase
- add corresponding unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683b3ef7d1188326b54efb104ab69f59