### PR TITLE
Add animations to home page

### DIFF
--- a/drfeinote/app/globals.css
+++ b/drfeinote/app/globals.css
@@ -120,3 +120,32 @@
     @apply bg-background text-foreground;
   }
 }
+
+@layer utilities {
+  .animate-fade-in {
+    animation: fadeIn 0.4s ease-out both;
+  }
+  .animate-fade-in-up {
+    animation: fadeInUp 0.4s ease-out both;
+  }
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(0.5rem);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/drfeinote/app/page.tsx
+++ b/drfeinote/app/page.tsx
@@ -49,7 +49,7 @@ export default function Home() {
         {/* Quick Actions */}
         <div className="grid gap-6 md:grid-cols-3 mb-8">
           <Link href="/meetings/new">
-            <Card className="transition-all hover:shadow-md cursor-pointer">
+            <Card className="transition-transform hover:scale-105 hover:shadow-md cursor-pointer animate-fade-in-up">
               <CardHeader className="flex flex-row items-center space-y-0 pb-2">
                 <CardTitle className="text-sm font-medium">New Meeting</CardTitle>
                 <PlusIcon className="h-4 w-4 ml-auto" />
@@ -64,7 +64,7 @@ export default function Home() {
           </Link>
 
           <Link href="/archive">
-            <Card className="transition-all hover:shadow-md cursor-pointer">
+            <Card className="transition-transform hover:scale-105 hover:shadow-md cursor-pointer animate-fade-in-up">
               <CardHeader className="flex flex-row items-center space-y-0 pb-2">
                 <CardTitle className="text-sm font-medium">Archive</CardTitle>
                 <ArchiveIcon className="h-4 w-4 ml-auto" />
@@ -79,7 +79,7 @@ export default function Home() {
           </Link>
 
           <Link href="/glossary">
-            <Card className="transition-all hover:shadow-md cursor-pointer">
+            <Card className="transition-transform hover:scale-105 hover:shadow-md cursor-pointer animate-fade-in-up">
               <CardHeader className="flex flex-row items-center space-y-0 pb-2">
                 <CardTitle className="text-sm font-medium">Glossary</CardTitle>
                 <BookOpenIcon className="h-4 w-4 ml-auto" />

--- a/drfeinote/components/meeting-list.tsx
+++ b/drfeinote/components/meeting-list.tsx
@@ -20,10 +20,10 @@ export function MeetingList({ meetings, emptyMessage }: MeetingListProps) {
   }
 
   return (
-    <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+    <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3 animate-fade-in">
       {meetings.map((meeting) => (
-        <Link key={meeting.meeting_id} href={`/meetings/${meeting.meeting_id}`}>
-          <Card className="h-full transition-all hover:shadow-md">
+        <Link key={meeting.meeting_id} href={`/meetings/${meeting.meeting_id}`}> 
+          <Card className="h-full transition-transform hover:scale-[1.02] hover:shadow-md animate-fade-in-up">
             <CardHeader>
               <CardTitle className="line-clamp-1">{meeting.topic_overview}</CardTitle>
               <CardDescription>


### PR DESCRIPTION
## Summary
- animate UI elements for a more dynamic home page
- add fade-in utility classes and keyframes
- highlight quick action buttons with hover animation
- animate meeting list cards

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683b3eb8ee788326b4505dea21a4f8d6