### PR TITLE
Add Supabase services and hook up home page

### DIFF
--- a/drfeinote/app/page.tsx
+++ b/drfeinote/app/page.tsx
@@ -5,26 +5,17 @@ import { MeetingList } from "@/components/meeting-list"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { PlusIcon, BookOpenIcon, ArchiveIcon } from "lucide-react"
 import Link from "next/link"
-
-// Mock data for demonstration - in a real app this would come from a database
-const recentMeetings = [
-  {
-    meeting_id: 1,
-    topic_overview: "Weekly Research Review",
-    meeting_date: "2024-01-15",
-    start_time: "14:00:00",
-    end_time: "15:30:00"
-  },
-  {
-    meeting_id: 2, 
-    topic_overview: "Project Planning Session",
-    meeting_date: "2024-01-12",
-    start_time: "10:00:00",
-    end_time: "11:00:00"
-  }
-]
+import { useEffect, useState } from "react"
+import { getMeetings } from "./actions"
+import type { Meeting } from "@/lib/types"
 
 export default function Home() {
+  const [recentMeetings, setRecentMeetings] = useState<Meeting[]>([])
+
+  useEffect(() => {
+    getMeetings('upcoming').then(setRecentMeetings).catch(console.error)
+  }, [])
+
   return (
     <div className="min-h-screen bg-background">
       {/* Header with Navigation */}

--- a/drfeinote/lib/__tests__/meeting-notes.test.ts
+++ b/drfeinote/lib/__tests__/meeting-notes.test.ts
@@ -1,0 +1,83 @@
+import { MeetingNotesService } from '../meeting-notes'
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+test('create inserts a meeting note', async () => {
+  const calls: any[] = []
+  const supabase = {
+    from: (table: string) => ({
+      insert: (vals: any) => {
+        calls.push({ table, vals })
+        return {
+          select: () => ({
+            single: async () => ({ data: { note_id: 1, ...vals }, error: null })
+          })
+        }
+      }
+    })
+  }
+
+  const svc = new MeetingNotesService(supabase as any)
+  const note = await svc.create(1, 'text')
+  assert.deepEqual(calls[0], { table: 'meeting_notes', vals: { meeting_id: 1, note_content: 'text' } })
+  assert.equal(note.note_content, 'text')
+})
+
+test('getById selects a note by id', async () => {
+  const calls: any[] = []
+  const supabase = {
+    from: (table: string) => ({
+      select: () => ({
+        eq: (field: string, value: any) => {
+          calls.push({ table, field, value })
+          return { maybeSingle: async () => ({ data: null, error: null }) }
+        }
+      })
+    })
+  }
+
+  const svc = new MeetingNotesService(supabase as any)
+  await svc.getById(5)
+  assert.deepEqual(calls[0], { table: 'meeting_notes', field: 'note_id', value: 5 })
+})
+
+test('update changes note content', async () => {
+  const calls: any[] = []
+  const supabase = {
+    from: (table: string) => ({
+      update: (vals: any) => ({
+        eq: (field: string, value: any) => {
+          calls.push({ table, field, value, vals })
+          return {
+            select: () => ({
+              single: async () => ({ data: { note_id: value, ...vals }, error: null })
+            })
+          }
+        }
+      })
+    })
+  }
+
+  const svc = new MeetingNotesService(supabase as any)
+  const note = await svc.update(3, 'updated')
+  assert.deepEqual(calls[0], { table: 'meeting_notes', field: 'note_id', value: 3, vals: { note_content: 'updated' } })
+  assert.equal(note.note_content, 'updated')
+})
+
+test('delete removes a note', async () => {
+  const calls: any[] = []
+  const supabase = {
+    from: (table: string) => ({
+      delete: () => ({
+        eq: (field: string, value: any) => {
+          calls.push({ table, field, value })
+          return { error: null }
+        }
+      })
+    })
+  }
+
+  const svc = new MeetingNotesService(supabase as any)
+  await svc.delete(2)
+  assert.deepEqual(calls[0], { table: 'meeting_notes', field: 'note_id', value: 2 })
+})

--- a/drfeinote/lib/__tests__/meetings.test.ts
+++ b/drfeinote/lib/__tests__/meetings.test.ts
@@ -1,0 +1,41 @@
+import { MeetingsService } from '../meetings'
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+test('getUpcoming selects upcoming meetings', async () => {
+  const calls: any[] = []
+  const supabase = {
+    from: (table: string) => ({
+      select: () => ({
+        gte: (field: string, value: any) => ({
+          order: (f: string, opts?: any) => {
+            calls.push({ table, field, value, orderField: f, opts })
+            return { data: [], error: null }
+          }
+        })
+      })
+    })
+  }
+
+  const svc = new MeetingsService(supabase as any)
+  await svc.getUpcoming()
+  assert.equal(calls[0].table, 'meetings')
+})
+
+test('getById selects by meeting_id', async () => {
+  const calls: any[] = []
+  const supabase = {
+    from: (table: string) => ({
+      select: () => ({
+        eq: (field: string, value: any) => {
+          calls.push({ table, field, value })
+          return { maybeSingle: async () => ({ data: null, error: null }) }
+        }
+      })
+    })
+  }
+
+  const svc = new MeetingsService(supabase as any)
+  await svc.getById(3)
+  assert.deepEqual(calls[0], { table: 'meetings', field: 'meeting_id', value: 3 })
+})

--- a/drfeinote/lib/meeting-notes.ts
+++ b/drfeinote/lib/meeting-notes.ts
@@ -1,0 +1,70 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import type { MeetingNote } from './types'
+
+/**
+ * Service class for CRUD operations on meeting notes using Supabase.
+ */
+export class MeetingNotesService {
+  constructor(private supabase: SupabaseClient) {}
+
+  /**
+   * Create a meeting note for a meeting.
+   */
+  async create(meetingId: number, content: string): Promise<MeetingNote> {
+    const { data, error } = await this.supabase
+      .from('meeting_notes')
+      .insert({ meeting_id: meetingId, note_content: content })
+      .select()
+      .single()
+
+    if (error) throw error
+    return data as MeetingNote
+  }
+
+  /** Get a meeting note by its id. */
+  async getById(noteId: number): Promise<MeetingNote | null> {
+    const { data, error } = await this.supabase
+      .from('meeting_notes')
+      .select('*')
+      .eq('note_id', noteId)
+      .maybeSingle()
+
+    if (error) throw error
+    return data as MeetingNote | null
+  }
+
+  /** Get the meeting note for a specific meeting. */
+  async getByMeetingId(meetingId: number): Promise<MeetingNote | null> {
+    const { data, error } = await this.supabase
+      .from('meeting_notes')
+      .select('*')
+      .eq('meeting_id', meetingId)
+      .maybeSingle()
+
+    if (error) throw error
+    return data as MeetingNote | null
+  }
+
+  /** Update the content of a meeting note. */
+  async update(noteId: number, content: string): Promise<MeetingNote> {
+    const { data, error } = await this.supabase
+      .from('meeting_notes')
+      .update({ note_content: content })
+      .eq('note_id', noteId)
+      .select()
+      .single()
+
+    if (error) throw error
+    return data as MeetingNote
+  }
+
+  /** Delete a meeting note. */
+  async delete(noteId: number): Promise<void> {
+    const { error } = await this.supabase
+      .from('meeting_notes')
+      .delete()
+      .eq('note_id', noteId)
+
+    if (error) throw error
+  }
+}

--- a/drfeinote/lib/meetings.ts
+++ b/drfeinote/lib/meetings.ts
@@ -1,0 +1,45 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import type { Meeting } from './types'
+
+/** Service class for reading meetings from Supabase. */
+export class MeetingsService {
+  constructor(private supabase: SupabaseClient) {}
+
+  /** Get upcoming meetings (meeting_date >= today). */
+  async getUpcoming(): Promise<Meeting[]> {
+    const today = new Date().toISOString().split('T')[0]
+    const { data, error } = await this.supabase
+      .from('meetings')
+      .select('*')
+      .gte('meeting_date', today)
+      .order('meeting_date')
+
+    if (error) throw error
+    return data as Meeting[]
+  }
+
+  /** Get past meetings (meeting_date < today). */
+  async getPast(): Promise<Meeting[]> {
+    const today = new Date().toISOString().split('T')[0]
+    const { data, error } = await this.supabase
+      .from('meetings')
+      .select('*')
+      .lt('meeting_date', today)
+      .order('meeting_date', { ascending: false })
+
+    if (error) throw error
+    return data as Meeting[]
+  }
+
+  /** Fetch a meeting by its id. */
+  async getById(id: number): Promise<Meeting | null> {
+    const { data, error } = await this.supabase
+      .from('meetings')
+      .select('*')
+      .eq('meeting_id', id)
+      .maybeSingle()
+
+    if (error) throw error
+    return data as Meeting | null
+  }
+}

--- a/drfeinote/lib/supabase-server.ts
+++ b/drfeinote/lib/supabase-server.ts
@@ -1,0 +1,9 @@
+import { createClient } from '@supabase/supabase-js'
+
+/**
+ * Server-side Supabase client using environment variables.
+ */
+export const supabaseServer = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+)


### PR DESCRIPTION
## Summary
- implement `MeetingsService` with Supabase queries
- add server-side Supabase client helper
- use services in server actions instead of mock data
- load meetings on the home page from Supabase
- add unit tests for new service

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683b3ef7d1188326b54efb104ab69f59