### PR TITLE
Add schedule page

### DIFF
--- a/app/schedule/page.tsx
+++ b/app/schedule/page.tsx
@@ -1,0 +1,15 @@
+import { getMeetings } from "../actions"
+import { MeetingList } from "@/components/meeting-list"
+
+export default async function SchedulePage() {
+  const upcomingMeetings = await getMeetings("upcoming")
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold tracking-tight">Schedule</h1>
+        <p className="text-muted-foreground">View and manage your upcoming meetings.</p>
+      </div>
+      <MeetingList meetings={upcomingMeetings} emptyMessage="No meetings scheduled." />
+    </div>
+  )
+}

--- a/components/main-nav.tsx
+++ b/components/main-nav.tsx
@@ -39,6 +39,11 @@ export function MainNav() {
       icon: CalendarIcon,
     },
     {
+      name: "Schedule",
+      href: "/schedule",
+      icon: CalendarIcon,
+    },
+    {
       name: "Archive",
       href: "/archive",
       icon: ArchiveIcon,


### PR DESCRIPTION
## Summary
- add a new `/schedule` route that lists upcoming meetings
- expose the schedule page in the main navigation

## Testing
- `npm test` *(fails: SyntaxError in lib/__tests__/meeting-notes.test.js)*

------
https://chatgpt.com/codex/tasks/task_b_683b7db5e9f08326accc1ea16ed4fc6a