### PR TITLE
Add theme toggle

### DIFF
--- a/components/main-nav.tsx
+++ b/components/main-nav.tsx
@@ -9,6 +9,7 @@ import { CalendarIcon, ArchiveIcon, BookOpenIcon } from "lucide-react"
 import { supabase } from "@/lib/supabase"
 import { Button } from "@/components/ui/button"
 import { signOut } from "@/lib/auth"
+import { ThemeToggle } from "@/components/theme-toggle"
 
 export function MainNav() {
   const pathname = usePathname()
@@ -76,7 +77,8 @@ export function MainNav() {
           </Link>
         ))}
       </div>
-      <div className="ml-auto">
+      <div className="ml-auto flex items-center space-x-2">
+        <ThemeToggle />
         {session ? (
           <Button variant="ghost" size="sm" onClick={handleSignOut}>
             Sign Out

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -1,0 +1,36 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { Moon, Sun } from "lucide-react"
+import { Button } from "@/components/ui/button"
+
+export function ThemeToggle() {
+  const [isDark, setIsDark] = useState(false)
+
+  useEffect(() => {
+    const root = document.documentElement
+    const stored = localStorage.getItem("theme")
+    const enabled = stored ? stored === "dark" : root.classList.contains("dark")
+    root.classList.toggle("dark", enabled)
+    setIsDark(enabled)
+  }, [])
+
+  const toggleTheme = () => {
+    const root = document.documentElement
+    root.classList.toggle("dark")
+    const dark = root.classList.contains("dark")
+    setIsDark(dark)
+    localStorage.setItem("theme", dark ? "dark" : "light")
+  }
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={toggleTheme}
+      aria-label="Toggle theme"
+    >
+      {isDark ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+    </Button>
+  )
+}


### PR DESCRIPTION
## Summary
- add a ThemeToggle component for dark/light mode
- integrate ThemeToggle into the main navigation

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: SyntaxError in meeting-notes.test.js)*

------
https://chatgpt.com/codex/tasks/task_b_683b819eb1148326b013d68122a2a260