### PR TITLE
Add meeting creation flow

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -21,6 +21,12 @@ export async function getMeeting(id: number): Promise<Meeting | null> {
   return meetingsSvc.getById(id)
 }
 
+export async function createMeeting(
+  meeting: Omit<Meeting, 'meeting_id'>
+): Promise<Meeting> {
+  return meetingsSvc.create(meeting)
+}
+
 export async function getMeetingNotes(meetingId: number): Promise<MeetingNote | null> {
   return notesSvc.getByMeetingId(meetingId)
 }

--- a/app/meetings/new/page.tsx
+++ b/app/meetings/new/page.tsx
@@ -1,10 +1,88 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { createMeeting } from '@/app/actions'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+import { useToast } from '@/hooks/use-toast'
+
 export default function NewMeetingPage() {
+  const [meetingDate, setMeetingDate] = useState('')
+  const [startTime, setStartTime] = useState('')
+  const [endTime, setEndTime] = useState('')
+  const [topic, setTopic] = useState('')
+  const [isSaving, setIsSaving] = useState(false)
+  const router = useRouter()
+  const { toast } = useToast()
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setIsSaving(true)
+    try {
+      const meeting = await createMeeting({
+        meeting_date: meetingDate,
+        start_time: startTime,
+        end_time: endTime,
+        topic_overview: topic,
+      })
+      toast({ title: 'Meeting scheduled' })
+      router.push(`/meetings/${meeting.meeting_id}`)
+    } catch (err) {
+      toast({
+        title: 'Error scheduling meeting',
+        variant: 'destructive',
+      })
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
   return (
-    <div className="space-y-6">
+    <div className="max-w-xl mx-auto space-y-6">
       <div>
         <h1 className="text-3xl font-bold tracking-tight">Schedule a New Meeting</h1>
-        <p className="text-muted-foreground">Feature coming soon.</p>
+        <p className="text-muted-foreground">Enter details for your meeting.</p>
       </div>
+      <Card>
+        <CardContent className="pt-6">
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <Input
+              type="date"
+              value={meetingDate}
+              onChange={(e) => setMeetingDate(e.target.value)}
+              required
+            />
+            <div className="flex gap-2">
+              <Input
+                type="time"
+                value={startTime}
+                onChange={(e) => setStartTime(e.target.value)}
+                required
+                className="flex-1"
+              />
+              <Input
+                type="time"
+                value={endTime}
+                onChange={(e) => setEndTime(e.target.value)}
+                required
+                className="flex-1"
+              />
+            </div>
+            <Textarea
+              value={topic}
+              onChange={(e) => setTopic(e.target.value)}
+              placeholder="Topic overview"
+              required
+            />
+            <Button type="submit" disabled={isSaving}>
+              {isSaving ? 'Saving...' : 'Create Meeting'}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
     </div>
   )
 }

--- a/app/schedule/page.tsx
+++ b/app/schedule/page.tsx
@@ -1,13 +1,20 @@
 import { getMeetings } from "../actions"
 import { MeetingList } from "@/components/meeting-list"
+import Link from "next/link"
+import { Button } from "@/components/ui/button"
 
 export default async function SchedulePage() {
   const upcomingMeetings = await getMeetings("upcoming")
   return (
     <div className="space-y-6">
-      <div>
-        <h1 className="text-3xl font-bold tracking-tight">Schedule</h1>
-        <p className="text-muted-foreground">View and manage your upcoming meetings.</p>
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">Schedule</h1>
+          <p className="text-muted-foreground">View and manage your upcoming meetings.</p>
+        </div>
+        <Button asChild>
+          <Link href="/meetings/new">Add Meeting</Link>
+        </Button>
       </div>
       <MeetingList meetings={upcomingMeetings} emptyMessage="No meetings scheduled." />
     </div>

--- a/lib/__tests__/meetings.test.js
+++ b/lib/__tests__/meetings.test.js
@@ -48,3 +48,36 @@ test('getById selects a meeting by id', async () => {
   assert.deepEqual(calls[0], { table: 'meetings', field: 'meeting_id', value: 3 })
 })
 
+test('create inserts a meeting', async () => {
+  const calls = []
+  const supabase = {
+    from: (table) => ({
+      insert: (vals) => {
+        calls.push({ table, vals })
+        return {
+          select: () => ({
+            single: async () => ({ data: { meeting_id: 1, ...vals }, error: null })
+          })
+        }
+      }
+    })
+  }
+  const svc = new MeetingsService(supabase)
+  const meeting = await svc.create({
+    meeting_date: '2024-01-01',
+    start_time: '10:00',
+    end_time: '11:00',
+    topic_overview: 'Topic'
+  })
+  assert.deepEqual(calls[0], {
+    table: 'meetings',
+    vals: {
+      meeting_date: '2024-01-01',
+      start_time: '10:00',
+      end_time: '11:00',
+      topic_overview: 'Topic'
+    }
+  })
+  assert.equal(meeting.topic_overview, 'Topic')
+})
+

--- a/lib/meetings.ts
+++ b/lib/meetings.ts
@@ -16,6 +16,25 @@ export class MeetingsService {
   }
 
   /**
+   * Create a new meeting record.
+   *
+   * @param meeting - Meeting fields excluding the id
+   * @returns The newly created meeting
+   */
+  async create(
+    meeting: Omit<Meeting, 'meeting_id'>
+  ): Promise<Meeting> {
+    const { data, error } = await this.supabase
+      .from('meetings')
+      .insert(meeting)
+      .select()
+      .single()
+
+    if (error) throw error
+    return data as Meeting
+  }
+
+  /**
    * List upcoming or past meetings based on date.
    *
    * @param status - Whether to list `upcoming` or `past` meetings


### PR DESCRIPTION
## Summary
- implement MeetingsService.create to insert meetings
- add createMeeting action
- allow scheduling page to link to new meeting form
- build out meeting creation page with form
- test new MeetingsService.create behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683bd3bf0ce08326a1ffd8e264901023