### PR TITLE
Fix dynamic meeting detail pages param retrieval

### DIFF
--- a/app/meetings/[id]/page.tsx
+++ b/app/meetings/[id]/page.tsx
@@ -1,4 +1,4 @@
-import { notFound, params as getParams } from "next/navigation"
+import { notFound } from "next/navigation"
 import { getMeeting, getMeetingNotes, getQnAForMeeting } from "@/app/actions"
 import { formatDate } from "@/lib/utils"
 import { NotesEditor } from "@/components/notes-editor"
@@ -7,8 +7,12 @@ import { Button } from "@/components/ui/button"
 import { ArrowLeft, Clock } from "lucide-react"
 import Link from "next/link"
 
-export default async function MeetingDetailPage() {
-  const { id } = await getParams<{ id: string }>()
+export default async function MeetingDetailPage({
+  params,
+}: {
+  params: { id: string }
+}) {
+  const { id } = params
   const meetingId = Number.parseInt(id)
 
   if (isNaN(meetingId)) {

--- a/app/recent/[id]/page.tsx
+++ b/app/recent/[id]/page.tsx
@@ -1,4 +1,4 @@
-import { notFound, params as getParams } from "next/navigation"
+import { notFound } from "next/navigation"
 import { getMeeting, getMeetingNotes, getQnAForMeeting } from "@/app/actions"
 import { formatDate } from "@/lib/utils"
 import { NotesEditor } from "@/components/notes-editor"
@@ -8,8 +8,12 @@ import { ArrowLeft, Clock } from "lucide-react"
 import Link from "next/link"
 import { FadeIn, SlideUp, StaggerContainer, StaggerItem } from "@/components/ui/motion"
 
-export default async function MeetingDetailPage() {
-  const { id } = await getParams<{ id: string }>()
+export default async function MeetingDetailPage({
+  params,
+}: {
+  params: { id: string }
+}) {
+  const { id } = params
   const meetingId = Number.parseInt(id)
 
   if (isNaN(meetingId)) {


### PR DESCRIPTION
## Summary
- fix dynamic pages using `params` function
- fetch the `id` from component `params` prop instead

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683bd52a9d8c8326a0b629be9c9a202d