### PR TITLE
Enable editing meeting details

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -27,6 +27,13 @@ export async function createMeeting(
   return meetingsSvc.create(meeting)
 }
 
+export async function updateMeeting(
+  id: number,
+  updates: Partial<Omit<Meeting, 'meeting_id'>>
+): Promise<Meeting> {
+  return meetingsSvc.update(id, updates)
+}
+
 export async function getMeetingNotes(meetingId: number): Promise<MeetingNote | null> {
   return notesSvc.getByMeetingId(meetingId)
 }

--- a/app/meetings/[id]/edit/page.tsx
+++ b/app/meetings/[id]/edit/page.tsx
@@ -1,0 +1,19 @@
+import { notFound } from "next/navigation"
+import { getMeeting } from "@/app/actions"
+import type { Meeting } from "@/lib/types"
+import { EditMeetingForm } from "@/components/edit-meeting-form"
+
+export default async function EditMeetingPage({ params }: { params: { id: string } }) {
+  const meetingId = Number.parseInt(params.id)
+
+  if (isNaN(meetingId)) {
+    notFound()
+  }
+
+  const meeting = await getMeeting(meetingId)
+  if (!meeting) {
+    notFound()
+  }
+
+  return <EditMeetingForm meeting={meeting} />
+}

--- a/app/meetings/[id]/page.tsx
+++ b/app/meetings/[id]/page.tsx
@@ -52,14 +52,17 @@ export default async function MeetingDetailPage({
             </span>
           </div>
         </div>
-        <div>
+        <div className="flex items-center gap-2">
           <span className={`inline-flex items-center px-3 py-1 rounded-full text-xs font-medium ${
-            isPastMeeting 
-              ? "bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200" 
+            isPastMeeting
+              ? "bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200"
               : "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200"
           }`}>
             {isPastMeeting ? "Past Meeting" : "Upcoming Meeting"}
           </span>
+          <Button size="sm" variant="outline" asChild>
+            <Link href={`/meetings/${meetingId}/edit`}>Edit</Link>
+          </Button>
         </div>
       </div>
 

--- a/components/edit-meeting-form.tsx
+++ b/components/edit-meeting-form.tsx
@@ -1,0 +1,82 @@
+"use client"
+
+import { useState } from "react"
+import { useRouter } from "next/navigation"
+import type { Meeting } from "@/lib/types"
+import { updateMeeting } from "@/app/actions"
+import { Card, CardContent } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import { Button } from "@/components/ui/button"
+import { useToast } from "@/hooks/use-toast"
+
+interface EditMeetingFormProps {
+  meeting: Meeting
+}
+
+export function EditMeetingForm({ meeting }: EditMeetingFormProps) {
+  const [startTime, setStartTime] = useState(meeting.start_time)
+  const [endTime, setEndTime] = useState(meeting.end_time)
+  const [topic, setTopic] = useState(meeting.topic_overview)
+  const [isSaving, setIsSaving] = useState(false)
+  const router = useRouter()
+  const { toast } = useToast()
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    setIsSaving(true)
+    try {
+      await updateMeeting(meeting.meeting_id, {
+        start_time: startTime,
+        end_time: endTime,
+        topic_overview: topic,
+      })
+      toast({ title: "Meeting updated" })
+      router.push(`/meetings/${meeting.meeting_id}`)
+    } catch (err) {
+      toast({ title: "Error updating meeting", variant: "destructive" })
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  return (
+    <div className="max-w-xl mx-auto space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold tracking-tight">Edit Meeting</h1>
+      </div>
+      <Card>
+        <CardContent className="pt-6">
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <Input type="date" value={meeting.meeting_date} disabled />
+            <div className="flex gap-2">
+              <Input
+                type="time"
+                value={startTime}
+                onChange={(e) => setStartTime(e.target.value)}
+                required
+                className="flex-1"
+              />
+              <Input
+                type="time"
+                value={endTime}
+                onChange={(e) => setEndTime(e.target.value)}
+                required
+                className="flex-1"
+              />
+            </div>
+            <Textarea
+              value={topic}
+              onChange={(e) => setTopic(e.target.value)}
+              required
+            />
+            <Button type="submit" disabled={isSaving}>
+              {isSaving ? "Saving..." : "Save Changes"}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+

--- a/lib/__tests__/meetings.test.js
+++ b/lib/__tests__/meetings.test.js
@@ -81,3 +81,41 @@ test('create inserts a meeting', async () => {
   assert.equal(meeting.topic_overview, 'Topic')
 })
 
+test('update modifies meeting fields', async () => {
+  const calls = []
+  const supabase = {
+    from: (table) => ({
+      update: (vals) => ({
+        eq: (field, value) => {
+          calls.push({ table, field, value, vals })
+          return {
+            select: () => ({
+              single: async () => ({
+                data: { meeting_id: value, ...vals },
+                error: null,
+              }),
+            }),
+          }
+        },
+      }),
+    }),
+  }
+  const svc = new MeetingsService(supabase)
+  const meeting = await svc.update(2, {
+    start_time: '09:00',
+    end_time: '10:00',
+    topic_overview: 'Updated',
+  })
+  assert.deepEqual(calls[0], {
+    table: 'meetings',
+    field: 'meeting_id',
+    value: 2,
+    vals: {
+      start_time: '09:00',
+      end_time: '10:00',
+      topic_overview: 'Updated',
+    },
+  })
+  assert.equal(meeting.topic_overview, 'Updated')
+})
+

--- a/lib/meetings.ts
+++ b/lib/meetings.ts
@@ -73,4 +73,26 @@ export class MeetingsService {
     if (error) throw error
     return data ?? null
   }
+
+  /**
+   * Update an existing meeting record.
+   *
+   * @param meetingId - Identifier of the meeting to update
+   * @param updates - Fields to update
+   * @returns The updated meeting
+   */
+  async update(
+    meetingId: number,
+    updates: Partial<Omit<Meeting, 'meeting_id'>>
+  ): Promise<Meeting> {
+    const { data, error } = await this.supabase
+      .from('meetings')
+      .update(updates)
+      .eq('meeting_id', meetingId)
+      .select()
+      .single()
+
+    if (error) throw error
+    return data as Meeting
+  }
 }


### PR DESCRIPTION
## Summary
- add `update` to MeetingsService
- expose `updateMeeting` server action
- link to an edit page from meeting detail screen
- implement form to edit a meeting
- test meeting update logic
- refactor edit page to use a client component

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_683be08722508326ac955cdbcd7aef97