### PR TITLE
Enable editing meeting date

### DIFF
--- a/components/edit-meeting-form.tsx
+++ b/components/edit-meeting-form.tsx
@@ -15,6 +15,7 @@ interface EditMeetingFormProps {
 }
 
 export function EditMeetingForm({ meeting }: EditMeetingFormProps) {
+  const [meetingDate, setMeetingDate] = useState(meeting.meeting_date)
   const [startTime, setStartTime] = useState(meeting.start_time)
   const [endTime, setEndTime] = useState(meeting.end_time)
   const [topic, setTopic] = useState(meeting.topic_overview)
@@ -27,6 +28,7 @@ export function EditMeetingForm({ meeting }: EditMeetingFormProps) {
     setIsSaving(true)
     try {
       await updateMeeting(meeting.meeting_id, {
+        meeting_date: meetingDate,
         start_time: startTime,
         end_time: endTime,
         topic_overview: topic,
@@ -48,7 +50,12 @@ export function EditMeetingForm({ meeting }: EditMeetingFormProps) {
       <Card>
         <CardContent className="pt-6">
           <form onSubmit={handleSubmit} className="space-y-4">
-            <Input type="date" value={meeting.meeting_date} disabled />
+            <Input
+              type="date"
+              value={meetingDate}
+              onChange={(e) => setMeetingDate(e.target.value)}
+              required
+            />
             <div className="flex gap-2">
               <Input
                 type="time"

--- a/lib/__tests__/meetings.test.js
+++ b/lib/__tests__/meetings.test.js
@@ -102,6 +102,7 @@ test('update modifies meeting fields', async () => {
   }
   const svc = new MeetingsService(supabase)
   const meeting = await svc.update(2, {
+    meeting_date: '2024-02-01',
     start_time: '09:00',
     end_time: '10:00',
     topic_overview: 'Updated',
@@ -111,6 +112,7 @@ test('update modifies meeting fields', async () => {
     field: 'meeting_id',
     value: 2,
     vals: {
+      meeting_date: '2024-02-01',
       start_time: '09:00',
       end_time: '10:00',
       topic_overview: 'Updated',


### PR DESCRIPTION
## Summary
- allow changing meeting_date in the meeting edit form
- update tests for meeting update

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_683be48de5c8832680bb0548ddd74bec